### PR TITLE
Added main menu and customizability

### DIFF
--- a/rofi-usb-mount.sh
+++ b/rofi-usb-mount.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+rofi_cmd='rofi -dmenu show run -lines 5 -opacity "85" -bw 0 -width 30 -padding 20 -i'
+usb_re='sd[b-z]'
+
 usbcheck(){ \
-    mounteddrives="$(lsblk -rpo "name,type,size,mountpoint" | grep -v 'sda' | awk '$2=="part"&&$4!=""{printf "%s (%s)\t  ",$1,$3}')"
+    mounteddrives="$(lsblk -rpo "name,type,size,mountpoint" | grep $usb_re | awk '$2=="part"&&$4!=""{printf "%s (%s)\t  ",$1,$3}')"
     if [ $(echo "$mounteddrives" | wc -w) -gt 0 ]; then
         echo "  #  $mounteddrives"
     else
@@ -14,27 +17,27 @@ usbcheck(){ \
 }
 
 mountusb(){ \
-    chosen=$(echo "$usbdrives" | rofi -dmenu -show run -lines 5 -opacity "85" -bw 0 -width 30 -padding 20 -i -p "Mount which drive?" | awk '{print $1}')
+    chosen=$(echo "$usbdrives" | $rofi_cmd -p "Mount which drive?" | awk '{print $1}')
     mountpoint=$(udisksctl mount --no-user-interaction -b "$chosen" 2>/dev/null) && notify-send "💻 USB mounting" "$chosen mounted to $mountpoint" && exit 0
 
 }
 
 umountusb(){ \
-    chosen=$(echo "$mounteddrives" | rofi -dmenu -show run -lines 5 -opacity "85" -bw 0 -width 30 -padding 20 -i -p "Unmount which drive?" | awk '{print $1}')
+    chosen=$(echo "$mounteddrives" | $rofi_cmd -p "Unmount which drive?" | awk '{print $1}')
     mountpoint=$(udisksctl unmount --no-user-interaction -b "$chosen" 2>/dev/null) && notify-send "💻 USB unmounting" "$chosen mounted" && exit 0
     udisksctl power-off --no-user-interaction -b "$chosen"
 }
 
 umountall(){ \
-    for chosen in $(echo $(lsblk -rpo "name,type,size,mountpoint" | grep -v 'sda' | awk '$2=="part"&&$4!=""{printf "%s\n",$1}')); do
+    for chosen in $(echo $(lsblk -rpo "name,type,size,mountpoint" | grep $usb_re | awk '$2=="part"&&$4!=""{printf "%s\n",$1}')); do
         udisksctl unmount --no-user-interaction -b "$chosen"
         udisksctl power-off --no-user-interaction -b "$chosen"
     done
 }
 
 
-usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | grep -v 'sda' | awk '$2=="part"&&$4==""{printf "%s (%s)\n",$1,$3}')"
-mounteddrives="$(lsblk -rpo "name,type,size,mountpoint" | grep -v 'sda' | awk '$2=="part"&&$4!=""{printf "%s (%s)\n",$1,$3}')"
+usbdrives="$(lsblk -rpo "name,type,size,mountpoint" | grep $usb_re | awk '$2=="part"&&$4==""{printf "%s (%s)\n",$1,$3}')"
+mounteddrives="$(lsblk -rpo "name,type,size,mountpoint" | grep $usb_re | awk '$2=="part"&&$4!=""{printf "%s (%s)\n",$1,$3}')"
 
 case "$1" in
     --check)
@@ -63,5 +66,13 @@ case "$1" in
         else
             notify-send "No USB drive(s) to unmount." && exit
         fi
-         ;;
+        ;;
+    *)
+        mode="$(echo $'Mount...\nUnmount...\nUnmount all' | $rofi_cmd -p "USB menu")"
+        case "$mode" in
+            "Mount...") $0 --mount ;;
+            "Unmount...") $0 --umount ;;
+            "Unmount all") $0 --umount-all ;;
+        esac
+        ;;
 esac


### PR DESCRIPTION
The main menu is so that you can manage disks all from 1 command (to bind to a single hotkey, for example).

Users may want to customize the rofi menu display or which devices are listed. It's easy to do a substitution, but it's even easier to change just 2 lines at the top of the file.

Let me know what you think and I'll make any necessary changes. I can update the readme as well once you are satisfied.